### PR TITLE
Fix comment spacing

### DIFF
--- a/lib/coverage-summary.js
+++ b/lib/coverage-summary.js
@@ -37,7 +37,7 @@ function assertValidSummary(obj) {
 }
 
 /**
- * CoverageSummary provides a summary of code coverage . It exposes 4 properties,
+ * CoverageSummary provides a summary of code coverage. It exposes 4 properties,
  * `lines`, `statements`, `branches`, and `functions`. Each of these properties
  * is an object that has 4 keys `total`, `covered`, `skipped` and `pct`.
  * `pct` is a percentage number (0-100).


### PR DESCRIPTION
## Summary
- remove extra space in `coverage-summary.js` comment

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac150354833084587c0c40dd0d00