### PR TITLE
Fix findNearestContainer assertion

### DIFF
--- a/test/file.test.js
+++ b/test/file.test.js
@@ -1137,6 +1137,6 @@ describe('findNearestContainer missing loc defense', () => {
             3: { loc: loc(20, 20, 40, 40) }
         };
         assert.equal(findNearestContainer({ no: 'loc' }, map), null);
-        assert.equal(findNearestContainer(loc(30, 30, 35, 35), '3'));
+        assert.equal(findNearestContainer(loc(30, 30, 35, 35), map), '3');
     });
 });


### PR DESCRIPTION
## Summary
- fix assertion in `findNearestContainer` test

## Testing
- `npm test` *(fails: nyc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ab2439688330a981d171377fa4df