### PR TITLE
Fix findNearestContainer test

### DIFF
--- a/test/file.test.js
+++ b/test/file.test.js
@@ -1137,6 +1137,6 @@ describe('findNearestContainer missing loc defense', () => {
             3: { loc: loc(20, 20, 40, 40) }
         };
         assert.equal(findNearestContainer({ no: 'loc' }, map), null);
-        assert.equal(findNearestContainer(loc(30, 30, 35, 35), '3'));
+        assert.equal(findNearestContainer(loc(30, 30, 35, 35), map), '3');
     });
 });


### PR DESCRIPTION
## Summary
- ensure `findNearestContainer` test uses the map object

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841acb2258c83309470afac75705dd7