### PR TITLE
Fix return type doc

### DIFF
--- a/lib/coverage-map.js
+++ b/lib/coverage-map.js
@@ -80,7 +80,7 @@ class CoverageMap {
 
     /**
      * returns an array for file paths for which this map has coverage
-     * @returns {Array{string}} - array of files
+     * @returns {Array<string>} - array of files
      */
     files() {
         return Object.keys(this.data);


### PR DESCRIPTION
## Summary
- fix JSDoc generics formatting in `CoverageMap.files`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841acb4998c833081e6b382b6f0801a